### PR TITLE
fix bullet rendering on "Roll your own memory profiling"

### DIFF
--- a/roll_your_own_memory_profiling.html
+++ b/roll_your_own_memory_profiling.html
@@ -303,9 +303,12 @@ line):</p>
 the same as the <code>space</code> counters.</p>
 <p>We have 3 unique call stacks that allocate, in the same order as they
 appear in the text file (although order does not matter for
-<code>pprof</code>): - <code>b</code> &lt;- <code>a</code> &lt;-
-<code>main</code> - <code>a</code> &lt;- <code>main</code> -
-<code>b</code> &lt;- <code>main</code></p>
+<code>pprof</code>):
+<ul>
+<li><code>b</code> &lt;- <code>a</code> &lt;- <code>main</code></li>
+<li><code>a</code> &lt;- <code>main</code></li>
+<li><code>b</code> &lt;- <code>main</code></li>
+</ul>
 <p>Since our program is a Position Independant Executable (PIE), the
 loader picks a random address for where to load our program in virtual
 memory. Consequently, addresses collected from within our program have

--- a/roll_your_own_memory_profiling.md
+++ b/roll_your_own_memory_profiling.md
@@ -218,6 +218,7 @@ We see that at the end of the program, we have (looking at the first line):
 Since we never freed any memory, the `in use` counters are the same as the `space` counters.
 
 We have 3 unique call stacks that allocate, in the same order as they appear in the text file (although order does not matter for `pprof`):
+
 - `b` <- `a` <- `main`
 - `a` <- `main`
 - `b` <- `main`


### PR DESCRIPTION
Running `make` resulted in significant unrelated diffs. Only the changes for the bullets were kept.

Rendering before:
![before](https://github.com/gaultier/blog/assets/992997/9cda41dc-7d95-4934-b671-d43c5cf39cf5)

Rendering after:
![after](https://github.com/gaultier/blog/assets/992997/2a6b7f60-d446-4968-90c4-84ce29598f4c)

P.S. thank you for your writing :)
