### PR TITLE
fix typo in blog post

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
 <title>Philippe Gaultier's blog</title>
 <link href="https://gaultier.github.io/blog"/>
-<updated>2026-03-14T08:12:12+01:00</updated>
+<updated>2026-03-14T08:16:04+01:00</updated>
 <author>
   <name>Philippe Gaultier</name>
 </author>
@@ -389,7 +389,7 @@
 <title>How to make your own static site generator</title>
 <link href="https://gaultier.github.io/blog/how_to_make_your_own_static_site_generator.html"/>
 <id>urn:uuid:11e1f1d7-6105-5048-967d-7f57942f6260</id>
-<updated>2026-03-14T08:12:12+01:00</updated>
+<updated>2026-03-14T08:16:04+01:00</updated>
 <published>2026-03-09T16:05:54+01:00</published>
 </entry>
     </feed>

--- a/how_to_make_your_own_static_site_generator.html
+++ b/how_to_make_your_own_static_site_generator.html
@@ -615,7 +615,7 @@ Do not edit it by hand.
 <span class="line-number"></span><span class="code-hl">}</span>
 </code></pre>
 <p>Technically I could use the <a href="https://docs.rs/nohash-hasher/0.2.0/nohash_hasher/">nohash</a> crate to optimize a bit, since the key in the map is already a hash, no need to hash it a second time. But I don't bother for now.</p>
-<p>I never clear the cache, because my computer has so much memory. This has one advantage: if I undo a change when writing an article, and the work had already finished, I will hit the existing cache entry again. Crucially, all HTML files are written to disk every time, wether it was a cache hit or not. This is required to avoid the cache and the disk going out-of-sync.</p>
+<p>I never clear the cache, because my computer has so much memory. This has one advantage: if I undo a change when writing an article, and the work had already finished, I will hit the existing cache entry again. Crucially, all HTML files are written to disk every time, whether it was a cache hit or not. This is required to avoid the cache and the disk going out-of-sync.</p>
 <p>Skipping all this work is fine for one reason only: generating the HTML for an article is a pure function with immutable arguments. If it mutated a variable (for example a search index), I could not easily skip this work.</p>
 <p>This was an interesting lesson for me: no shared mutable variables (except the cache) makes parallel and incremental computations possible.</p>
 <p>Right now I do not (yet) generate the HTML for each article in parallel, because it's already plenty fast, but conceptually I could, since each article is fully independent from the others (again, except for the cache).</p>

--- a/how_to_make_your_own_static_site_generator.md
+++ b/how_to_make_your_own_static_site_generator.md
@@ -472,7 +472,7 @@ fn md_render_article(
 
 Technically I could use the [nohash](https://docs.rs/nohash-hasher/0.2.0/nohash_hasher/) crate to optimize a bit, since the key in the map is already a hash, no need to hash it a second time. But I don't bother for now.
  
-I never clear the cache, because my computer has so much memory. This has one advantage: if I undo a change when writing an article, and the work had already finished, I will hit the existing cache entry again. Crucially, all HTML files are written to disk every time, wether it was a cache hit or not. This is required to avoid the cache and the disk going out-of-sync.
+I never clear the cache, because my computer has so much memory. This has one advantage: if I undo a change when writing an article, and the work had already finished, I will hit the existing cache entry again. Crucially, all HTML files are written to disk every time, whether it was a cache hit or not. This is required to avoid the cache and the disk going out-of-sync.
 
 Skipping all this work is fine for one reason only: generating the HTML for an article is a pure function with immutable arguments. If it mutated a variable (for example a search index), I could not easily skip this work.
 


### PR DESCRIPTION
hey, noticed a small typo in the static site generator post - "wether" should be "whether". fixed it in the md and rebuilt the html.

let me know if you need anything else!